### PR TITLE
Update source map tracking for Webpack

### DIFF
--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -8,7 +8,7 @@ const customPath = path.join(__dirname, './customPublicPath');
 const hotScript = 'webpack-hot-middleware/client?path=/__webpack_hmr&dynamicPublicPath=true';
 
 const baseDevConfig = () => ({
-  devtool: 'eval-cheap-module-source-map',
+  devtool: 'eval-source-map',
   entry: {
     options: [customPath, hotScript, path.join(__dirname, '../chrome/extension/options')],
     background: [customPath, hotScript, path.join(__dirname, '../chrome/extension/background')],


### PR DESCRIPTION
Allows use to debug correctly.

May need to change it later if we hit performance issues but fairly unlikely for now.