### PR TITLE
Add notifications counter

### DIFF
--- a/chrome/extension/background/inject.js
+++ b/chrome/extension/background/inject.js
@@ -54,6 +54,22 @@ function injectDisplay(tabId, display) {
   });
 }
 
+function updateBadge() {
+  chrome.runtime.onMessage.addListener(
+    (request) => {
+      if (request.badge || request.badge === 0) {
+        const total = request.badge.toString();
+        // Use orange background for now
+        chrome.browserAction.setBadgeBackgroundColor({ color: [228, 144, 45, 50] });
+        if (total >= 1) {
+          chrome.browserAction.setBadgeText({ text: total });
+        } else {
+          chrome.browserAction.setBadgeText({ text: '' });
+        }
+      }
+    });
+}
+
 const arrowURLs = ['^https://www.chess\\.com'];
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
@@ -63,6 +79,8 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
       injectCSS(tabId, storage.style);
       injectDisplay(tabId, storage.display);
     });
+
+    updateBadge();
   }
 
   if (changeInfo.status !== 'loading' || !tab.url.match(arrowURLs.join('|'))) return;

--- a/chrome/extension/inject.js
+++ b/chrome/extension/inject.js
@@ -64,10 +64,31 @@ function reloadPage() {
   );
 }
 
+function getNotifications() {
+  const el = document.querySelectorAll('span[data-notifications]');
+  const nodes = [...el].splice(0, 3);
+  let total = 0;
+  nodes.map(target => {
+    const value = parseInt(target.dataset.notifications, 10);
+    total += value;
+    return value;
+  });
+  if (!total) {
+    total = 0;
+  }
+  chrome.runtime.sendMessage({
+    badge: total
+  });
+}
+
 window.addEventListener('load', () => {
   updateStyles();
   updateDisplay();
   reloadPage();
+
+  // Set a delay whilst we wait for on site to compute
+  // the totals for the DOM elements
+  setInterval(getNotifications, 1000);
 });
 
 window.addEventListener('message', (event) => {


### PR DESCRIPTION
Adds a notification counter to the browser action icon that is sync'd via an interval on the website via a background script.

Alleviates the need to an internal API endpoint at this stage.