### PR TITLE
Use a callback and setTimeout for sending notification count to badge

### DIFF
--- a/chrome/extension/background/inject.js
+++ b/chrome/extension/background/inject.js
@@ -55,19 +55,18 @@ function injectDisplay(tabId, display) {
 }
 
 function updateBadge() {
-  chrome.runtime.onMessage.addListener(
-    (request) => {
-      if (request.badge || request.badge === 0) {
-        const total = request.badge.toString();
-        // Use orange background for now
-        chrome.browserAction.setBadgeBackgroundColor({ color: [228, 144, 45, 50] });
-        if (total >= 1) {
-          chrome.browserAction.setBadgeText({ text: total });
-        } else {
-          chrome.browserAction.setBadgeText({ text: '' });
-        }
+  chrome.runtime.onMessage.addListener((request) => {
+    if (request.badge || request.badge === 0) {
+      const total = request.badge.toString();
+      // Use orange background for now
+      chrome.browserAction.setBadgeBackgroundColor({ color: [228, 144, 45, 50] });
+      if (total >= 1) {
+        chrome.browserAction.setBadgeText({ text: total });
+      } else {
+        chrome.browserAction.setBadgeText({ text: '' });
       }
-    });
+    }
+  });
 }
 
 const arrowURLs = ['^https://www.chess\\.com'];

--- a/chrome/extension/inject.js
+++ b/chrome/extension/inject.js
@@ -64,21 +64,25 @@ function reloadPage() {
   );
 }
 
-function getNotifications() {
-  const el = document.querySelectorAll('span[data-notifications]');
-  const nodes = [...el].splice(0, 3);
-  let total = 0;
-  nodes.map(target => {
-    const value = parseInt(target.dataset.notifications, 10);
-    total += value;
-    return value;
-  });
-  if (!total) {
-    total = 0;
-  }
-  chrome.runtime.sendMessage({
+function sendNotification(total, cb) {
+  return chrome.runtime.sendMessage({
     badge: total
-  });
+  }, cb);
+}
+
+function getNotifications() {
+  // Set a delay for getting notifcations
+  setTimeout(() => {
+    const el = document.querySelectorAll('span[data-notifications]');
+    const nodes = [...el].splice(0, 3);
+    let total = 0;
+    nodes.map(target => {
+      const value = parseInt(target.dataset.notifications, 10);
+      total += value;
+      return total;
+    });
+    return sendNotification(total, getNotifications);
+  }, 1000);
 }
 
 window.addEventListener('load', () => {
@@ -86,9 +90,11 @@ window.addEventListener('load', () => {
   updateDisplay();
   reloadPage();
 
-  // Set a delay whilst we wait for on site to compute
-  // the totals for the DOM elements
-  setInterval(getNotifications, 1000);
+  /**
+   * Set a delay whilst we wait for current page to compute all DOM
+   * elements that have notification attributes bound to them
+   */
+  setTimeout(getNotifications, 1000);
 });
 
 window.addEventListener('message', (event) => {


### PR DESCRIPTION
I noticed a tiny bug regarding a race condition where the badge text was removed because the interval was firing faster than the map function to calculate the totals.

The getting totals part is now triggered when the previous message is sent to prevent the flickering of badge text.