### PR TITLE
Slow down polling for notifications to 60 seconds

### DIFF
--- a/chrome/extension/inject.js
+++ b/chrome/extension/inject.js
@@ -82,7 +82,7 @@ function getNotifications() {
       return total;
     });
     return sendNotification(total, getNotifications);
-  }, 1000);
+  }, 30000);
 }
 
 window.addEventListener('load', () => {

--- a/chrome/extension/inject.js
+++ b/chrome/extension/inject.js
@@ -82,7 +82,7 @@ function getNotifications() {
       return total;
     });
     return sendNotification(total, getNotifications);
-  }, 30000);
+  }, 60000);
 }
 
 window.addEventListener('load', () => {

--- a/chrome/manifest.dev.json
+++ b/chrome/manifest.dev.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "Chess Browser Extension",
   "manifest_version": 2,
   "description": "Customize your Chess.com Experience",

--- a/chrome/manifest.prod.json
+++ b/chrome/manifest.prod.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "Chess Browser Extension",
   "manifest_version": 2,
   "description": "Customize your Chess.com Experience",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-browser-extension",
-  "version": "0.0.0",
+  "version": "0.0.7",
   "description": "Chess.com Browser Extension",
   "scripts": {
     "dev": "node scripts/dev",


### PR DESCRIPTION
We've been getting serious performance problems with having polling every second, particularly in Live Chess. Eventually we want to be able to detect notification change via web sockets but until then, this is our best choice. 

While we're at it, I'm also updating the version number in our package.json file. These might as well be in sync with our `manifest_version`. When we eventually come out with this extension in other browsers, we will have all of them share the same version number. 