### PR TITLE
Inform parent window that chess browser extension is installed

### DIFF
--- a/chrome/content.js
+++ b/chrome/content.js
@@ -1,3 +1,6 @@
 if (window.context) {
   window.postMessage(window.context.user, '*');
+  window.context.chessBrowserExtension = true;
 }
+
+

--- a/chrome/content.js
+++ b/chrome/content.js
@@ -2,5 +2,3 @@ if (window.context) {
   window.postMessage(window.context.user, '*');
   window.context.chessBrowserExtension = true;
 }
-
-


### PR DESCRIPTION
In UserSnap we want to know whether our extension is installed or not. If the complaint is regarding performance, it will be helpful to know whether the extension exists or not. 

I considered including version number of the browser extension but there would not be an easy way of doing this dynamically (we'd have to hardcode it) and since [Chrome extensions are autoupdated](https://developer.chrome.com/extensions/autoupdate), I think it's safe to assume that the user is on the latest release. We can revisit that in the future if it becomes an issue.