### PR TITLE
Actually reloading chess.com when Reset all is clicked

### DIFF
--- a/app/components/Reset.js
+++ b/app/components/Reset.js
@@ -14,7 +14,16 @@ export default class Reset extends Component {
         style: {},
         display: {}
       });
+      this.sendReload();
     }
+  }
+
+  sendReload = () => {
+    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+      chrome.tabs.sendMessage(tabs[0].id, {
+        update: 'reload'
+      });
+    });
   }
 
   render() {


### PR DESCRIPTION
Currently, the only way you get chess.com reloaded when clicking 'Reset all' is if you click it right after changing your configurations.

This changes will trigger the reload always.