### PR TITLE
Redirect to settings instead of home

### DIFF
--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -13,7 +13,7 @@ export default class Header extends Component {
     if (!this.props.user.loading) {
       if (this.props.user.loggedIn) {
         userInfo = (
-          <Link slug="settings/profile">
+          <Link slug={"member/" + this.props.user.username}>
             <div className={style.userInfo}>
               <span className={style.username}>{this.props.user.username}</span>
               <img role="presentation" width="25" src={`http:${this.props.user.avatarUrl}`} />

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -13,7 +13,7 @@ export default class Header extends Component {
     if (!this.props.user.loading) {
       if (this.props.user.loggedIn) {
         userInfo = (
-          <Link slug="settings">
+          <Link slug="settings/profile">
             <div className={style.userInfo}>
               <span className={style.username}>{this.props.user.username}</span>
               <img role="presentation" width="25" src={`http:${this.props.user.avatarUrl}`} />

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -13,7 +13,7 @@ export default class Header extends Component {
     if (!this.props.user.loading) {
       if (this.props.user.loggedIn) {
         userInfo = (
-          <Link slug={"member/" + this.props.user.username}>
+          <Link slug={`member/${this.props.user.username}`}>
             <div className={style.userInfo}>
               <span className={style.username}>{this.props.user.username}</span>
               <img role="presentation" width="25" src={`http:${this.props.user.avatarUrl}`} />

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -13,7 +13,7 @@ export default class Header extends Component {
     if (!this.props.user.loading) {
       if (this.props.user.loggedIn) {
         userInfo = (
-          <Link slug="home">
+          <Link slug="settings">
             <div className={style.userInfo}>
               <span className={style.username}>{this.props.user.username}</span>
               <img role="presentation" width="25" src={`http:${this.props.user.avatarUrl}`} />


### PR DESCRIPTION
The user should be redirected to /settings instead of /home when clicking the userInfo Link.