### PR TITLE
Feature/messages icons

### DIFF
--- a/app/components/NotificationBar.css
+++ b/app/components/NotificationBar.css
@@ -1,0 +1,20 @@
+.notificationBar{
+	background: white;
+	padding: 10px 0px 10px 0px;
+}
+.notificationBar div {      
+	position:relative;
+    display:inline-block;
+	margin-left: 20%;	
+}
+.notificationBar div span{
+    position: absolute;
+    right:-20px;
+    top:10px;
+    background:red;
+    text-align: center;
+    border-radius: 30px 30px 30px 30px;
+    color:white;
+    padding: 0px 5px 0px 5px;
+    font-size:10px;
+}

--- a/app/components/NotificationBar.js
+++ b/app/components/NotificationBar.js
@@ -1,0 +1,27 @@
+import React, { Component, PropTypes } from 'react';
+import style from './NotificationBar.css';
+import Icon from './Icon.js';
+import Link from './Link.js';
+
+export default class NotificationBar extends Component {
+  
+  render() {
+    let notifications= {games:1,messages:10,alerts:100};
+    return (
+      <div className={style.notificationBar}>
+           <Link slug="daily">
+             <Icon name="chess-pawn" size="28"/>
+             <span>{/*this.props.*/notifications.games}</span>
+           </Link>
+           <Link slug="messages">
+             <Icon name="mail" size="28"/>
+             <span>{/*this.props.*/notifications.messages}</span>
+           </Link>
+           <Link slug="daily">
+             <Icon name="chess-board" size="28"/>
+             <span>{/*this.props.*/notifications.alerts}</span>
+           </Link>
+      </div>
+    );
+  }
+}

--- a/app/components/NotificationBar.js
+++ b/app/components/NotificationBar.js
@@ -5,21 +5,34 @@ import Link from './Link.js';
 
 export default class NotificationBar extends Component {
   
+  static propTypes = {
+    notifications: PropTypes.object.isRequired,
+  };
+
   render() {
-    let notifications= {games:1,messages:10,alerts:100};
+    let games = (<span />);
+    let messages = (<span />);
+    let alerts = (<span />);
+    
+    if (!this.props.notifications.loading) {
+      games = (<span>{this.props.notifications.games}</span>);
+      messages = (<span>{this.props.notifications.messages}</span>);
+      alerts = (<span>{this.props.notifications.alerts}</span>);
+    }
+
     return (
       <div className={style.notificationBar}>
            <Link slug="daily">
              <Icon name="chess-pawn" size="28"/>
-             <span>{/*this.props.*/notifications.games}</span>
+             {games}
            </Link>
            <Link slug="messages">
              <Icon name="mail" size="28"/>
-             <span>{/*this.props.*/notifications.messages}</span>
+             {messages}
            </Link>
            <Link slug="daily">
              <Icon name="chess-board" size="28"/>
-             <span>{/*this.props.*/notifications.alerts}</span>
+             {alerts}
            </Link>
       </div>
     );

--- a/app/components/NotificationBar.js
+++ b/app/components/NotificationBar.js
@@ -4,7 +4,7 @@ import Icon from './Icon.js';
 import Link from './Link.js';
 
 export default class NotificationBar extends Component {
-  
+
   static propTypes = {
     notifications: PropTypes.object.isRequired,
   };
@@ -13,7 +13,7 @@ export default class NotificationBar extends Component {
     let games = (<span />);
     let messages = (<span />);
     let alerts = (<span />);
-    
+
     if (!this.props.notifications.loading) {
       games = (<span>{this.props.notifications.games}</span>);
       messages = (<span>{this.props.notifications.messages}</span>);
@@ -22,18 +22,18 @@ export default class NotificationBar extends Component {
 
     return (
       <div className={style.notificationBar}>
-           <Link slug="daily">
-             <Icon name="chess-pawn" size="28"/>
-             {games}
-           </Link>
-           <Link slug="messages">
-             <Icon name="mail" size="28"/>
-             {messages}
-           </Link>
-           <Link slug="daily">
-             <Icon name="chess-board" size="28"/>
-             {alerts}
-           </Link>
+        <Link slug="daily">
+          <Icon name="chess-pawn" size="28" />
+          {games}
+        </Link>
+        <Link slug="messages">
+          <Icon name="mail" size="28" />
+          {messages}
+        </Link>
+        <Link slug="daily">
+          <Icon name="chess-board" size="28" />
+          {alerts}
+        </Link>
       </div>
     );
   }

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import Header from '../components/Header';
+import NotificationBar from '../components/NotificationBar';
 import Icon from '../components/Icon';
 import PlayContainer from '../components/PlayContainer';
 import Options from '../components/Options/Options';
@@ -21,6 +22,7 @@ export default class App extends Component {
     return (
       <div className={style.normal}>
         <Header user={this.props.user} />
+        <NotificationBar />
         <PlayContainer user={this.props.user} />
         <Options />
         <div className={style.resetButton}>

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -10,7 +10,8 @@ import style from './App.css';
 export default class App extends Component {
 
   static propTypes = {
-    user: PropTypes.object.isRequired
+    user: PropTypes.object.isRequired,
+    notifications: PropTypes.object.isRequired
   };
 
   handleSuggestionsClick = () => {
@@ -22,7 +23,7 @@ export default class App extends Component {
     return (
       <div className={style.normal}>
         <Header user={this.props.user} />
-        <NotificationBar />
+        <NotificationBar notifications={this.props.notifications}/>
         <PlayContainer user={this.props.user} />
         <Options />
         <div className={style.resetButton}>

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -23,7 +23,7 @@ export default class App extends Component {
     return (
       <div className={style.normal}>
         <Header user={this.props.user} />
-        <NotificationBar notifications={this.props.notifications}/>
+        <NotificationBar notifications={this.props.notifications} />
         <PlayContainer user={this.props.user} />
         <Options />
         <div className={style.resetButton}>

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -12,11 +12,22 @@ export default class Root extends Component {
         onV3: null,
         onChessCom: null,
         loggedIn: null
+      },
+      notifications: {
+        loading: true,
+        games:'',
+        messages:'',
+        alerts:''
       }
-    };
-  }
+    }
+  } 
 
   componentDidMount() {
+    chrome.storage.sync.get('notifications', result => {
+      result.notifications.loading = false;
+      this.setState({ notifications: result.notifications });
+    });
+
     const user = this.state.user;
 
     this.calcLoggedIn(user).then((user1) => {
@@ -134,7 +145,7 @@ export default class Root extends Component {
     return this.setState({ user: userToSave });
   }
 
-  render() {
-    return React.createElement(App, { user: this.state.user });
+  render() {    
+    return React.createElement(App, { user: this.state.user, notifications: this.state.notifications });
   }
 }

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -24,7 +24,7 @@ export default class Root extends Component {
 
   componentDidMount() {
     chrome.storage.sync.get('notifications', result => {
-      var data = Object.assing({}, result.notifications);
+      const data = Object.assign({}, result.notifications);
       data.loading = false;
       this.setState({ notifications: data });
     });
@@ -147,7 +147,7 @@ export default class Root extends Component {
   }
 
   render() {
-    return React.createElement(App, { user: this.state.user, 
+    return React.createElement(App, { user: this.state.user,
       notifications: this.state.notifications });
   }
 }

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -15,17 +15,18 @@ export default class Root extends Component {
       },
       notifications: {
         loading: true,
-        games:'',
-        messages:'',
-        alerts:''
+        games: '',
+        messages: '',
+        alerts: ''
       }
-    }
-  } 
+    };
+  }
 
   componentDidMount() {
     chrome.storage.sync.get('notifications', result => {
-      result.notifications.loading = false;
-      this.setState({ notifications: result.notifications });
+      var data = Object.assing({}, result.notifications);
+      data.loading = false;
+      this.setState({ notifications: data });
     });
 
     const user = this.state.user;
@@ -145,7 +146,8 @@ export default class Root extends Component {
     return this.setState({ user: userToSave });
   }
 
-  render() {    
-    return React.createElement(App, { user: this.state.user, notifications: this.state.notifications });
+  render() {
+    return React.createElement(App, { user: this.state.user, 
+      notifications: this.state.notifications });
   }
 }

--- a/chrome/extension/inject.js
+++ b/chrome/extension/inject.js
@@ -72,15 +72,26 @@ function sendNotification(total, cb) {
 
 function getNotifications() {
   // Set a delay for getting notifcations
-  setTimeout(() => {
+  setTimeout(() => {    
     const el = document.querySelectorAll('span[data-notifications]');
     const nodes = [...el].splice(0, 3);
     let total = 0;
-    nodes.map(target => {
+
+    let notifications = {
+        games:'',
+        messages:'',
+        alerts:''
+    };
+    var notificationKeys = Object.keys( notifications );
+
+    nodes.map((target, index) => {
       const value = parseInt(target.dataset.notifications, 10);
       total += value;
+      if(value !== 0) notifications[notificationKeys[index]] = parseInt(target.dataset.notifications, 10);
       return total;
     });
+
+    chrome.storage.sync.set({'notifications': notifications });
     return sendNotification(total, getNotifications);
   }, 60000);
 }

--- a/chrome/extension/inject.js
+++ b/chrome/extension/inject.js
@@ -72,26 +72,28 @@ function sendNotification(total, cb) {
 
 function getNotifications() {
   // Set a delay for getting notifcations
-  setTimeout(() => {    
+  setTimeout(() => {
     const el = document.querySelectorAll('span[data-notifications]');
     const nodes = [...el].splice(0, 3);
     let total = 0;
 
-    let notifications = {
-        games:'',
-        messages:'',
-        alerts:''
+    const notifications = {
+      games: '',
+      messages: '',
+      alerts: ''
     };
-    var notificationKeys = Object.keys( notifications );
+    const notificationKeys = Object.keys(notifications);
 
     nodes.map((target, index) => {
       const value = parseInt(target.dataset.notifications, 10);
       total += value;
-      if(value !== 0) notifications[notificationKeys[index]] = parseInt(target.dataset.notifications, 10);
+      if (value !== 0) {
+        notifications[notificationKeys[index]] = parseInt(target.dataset.notifications, 10);
+      }
       return total;
     });
 
-    chrome.storage.sync.set({'notifications': notifications });
+    chrome.storage.sync.set({ notifications });
     return sendNotification(total, getNotifications);
   }, 60000);
 }


### PR DESCRIPTION
This closes #42 

This code on the `inject.js`:

```
const el = document.querySelectorAll('span[data-notifications]');
const nodes = [...el].splice(0, 3);
```

gives us these values:
```
[span.alert-notification-count.alert-notification-games.ng-hide, span.alert-notification-count.alert-notification-messages, span.alert-notification-count.alert-notification-alerts]
```

I know the second one `span.alert-notification-count.alert-notification-messages` is for the [messages](https://www.chess.com/messages) and the third one `span.alert-notification-count.alert-notification-alerts` is for the [daily](https://www.chess.com/daily), but I'm not sure what is the first one for.

Due to the explanation before, the first icon could no be the best fit for its action, please let me know what is the action of the first icon so I can select an appropriate icon and action for it.

This is how the extension looks with this changes:
![capture](https://cloud.githubusercontent.com/assets/4671080/20086265/4c24a7ba-a545-11e6-924b-2569ddd2484a.PNG)
