### PR TITLE
Add BaseComponent with shouldComponentUpdate

### DIFF
--- a/app/BaseComponent.js
+++ b/app/BaseComponent.js
@@ -1,0 +1,42 @@
+import React from 'react';
+
+function shallowComp(A, B) {
+  if (A === B) {
+    // They are the same object
+    return true;
+  }
+
+  if (typeof A !== 'object' || A === null ||
+      typeof B !== 'object' || B === null) {
+    // This is only meant for comparing objects
+    // If they are not the function could have unintended behaviour
+    return false;
+  }
+  
+  // Check that keys are the same
+  const keysA = Object.keys(A);
+  const keysB = Object.keys(B);
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+  return keysA.every(key => {
+    if (!B.hasOwnProperty(key)) {
+      return false;
+    }
+    return A[key] === B[key];
+  });
+}
+
+export default class BaseComponent extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    if (this.constructor === BaseComponent) {
+      throw new TypeError('BaseComponent is abstract');
+    }
+  }
+
+  shouldComponentUpdate = (nextProps, nextState) => {
+    return (!shallowComp(this.props, nextProps) ||
+            !shallowComp(this.state, nextState));
+  }
+}

--- a/app/BaseComponent.js
+++ b/app/BaseComponent.js
@@ -12,7 +12,7 @@ function shallowComp(A, B) {
     // If they are not the function could have unintended behaviour
     return false;
   }
-  
+
   // Check that keys are the same
   const keysA = Object.keys(A);
   const keysB = Object.keys(B);
@@ -20,7 +20,7 @@ function shallowComp(A, B) {
     return false;
   }
   return keysA.every(key => {
-    if (!B.hasOwnProperty(key)) {
+    if (!Object.hasOwnProperty.call(B, key)) {
       return false;
     }
     return A[key] === B[key];
@@ -35,8 +35,8 @@ export default class BaseComponent extends React.Component {
     }
   }
 
-  shouldComponentUpdate = (nextProps, nextState) => {
-    return (!shallowComp(this.props, nextProps) ||
-            !shallowComp(this.state, nextState));
-  }
+  shouldComponentUpdate = (nextProps, nextState) => (
+    !shallowComp(this.props, nextProps) ||
+    !shallowComp(this.state, nextState)
+  );
 }

--- a/app/components/Button.js
+++ b/app/components/Button.js
@@ -1,10 +1,11 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import classNames from 'classnames/bind';
 import style from '../components/Button.css';
+import BaseComponent from '../BaseComponent';
 
 const cx = classNames.bind(style);
 
-export default class Button extends Component {
+export default class Button extends BaseComponent {
 
   static propTypes = {
     onClick: PropTypes.func.isRequired,

--- a/app/components/ColorPicker.js
+++ b/app/components/ColorPicker.js
@@ -1,11 +1,12 @@
 /* eslint quote-props: 0 */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import { ChromePicker } from 'react-color';
 import reactCSS from 'reactcss';
 import style from './ColorPicker.css';
 import Icon from './Icon';
+import BaseComponent from '../BaseComponent';
 
-export default class ColorPicker extends Component {
+export default class ColorPicker extends BaseComponent {
 
   static propTypes = {
     name: PropTypes.string.isRequired,

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -1,8 +1,9 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import style from './Header.css';
 import Link from './Link';
+import BaseComponent from '../BaseComponent';
 
-export default class Header extends Component {
+export default class Header extends BaseComponent {
 
   static propTypes = {
     user: PropTypes.object.isRequired,

--- a/app/components/Icon.js
+++ b/app/components/Icon.js
@@ -1,11 +1,12 @@
 /* eslint quote-props: 0 */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import classNames from 'classnames/bind';
 import icon from './Icon.css';
+import BaseComponent from '../BaseComponent';
 
 const cx = classNames.bind(icon);
 
-export default class Icon extends Component {
+export default class Icon extends BaseComponent {
 
   static propTypes = {
     name: PropTypes.string.isRequired,

--- a/app/components/Link.js
+++ b/app/components/Link.js
@@ -1,7 +1,8 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import style from './Link.css';
+import BaseComponent from '../BaseComponent';
 
-export default class Link extends Component {
+export default class Link extends BaseComponent {
 
   static propTypes = {
     slug: PropTypes.string.isRequired,

--- a/app/components/NotificationBar.js
+++ b/app/components/NotificationBar.js
@@ -1,9 +1,10 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import style from './NotificationBar.css';
 import Icon from './Icon.js';
 import Link from './Link.js';
+import BaseComponent from '../BaseComponent';
 
-export default class NotificationBar extends Component {
+export default class NotificationBar extends BaseComponent {
 
   static propTypes = {
     notifications: PropTypes.object.isRequired,

--- a/app/components/Options/Options.js
+++ b/app/components/Options/Options.js
@@ -1,11 +1,12 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Config from './Config';
 import Icon from '../Icon';
 import ColorPicker from '../ColorPicker';
 import ToggleDisplay from '../ToggleDisplay';
 import style from './Options.css';
+import BaseComponent from '../../BaseComponent.js';
 
-export default class Options extends Component {
+export default class Options extends BaseComponent {
 
   constructor() {
     super();

--- a/app/components/Play.js
+++ b/app/components/Play.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import Variants from './Variants';
 import Times from './Times';
 import Button from './Button';
@@ -6,8 +6,9 @@ import Link from './Link';
 import Icon from '../components/Icon';
 import style from '../components/Play.css';
 import buttonStyle from '../components/Button.css';
+import BaseComponent from '../BaseComponent';
 
-export default class Play extends Component {
+export default class Play extends BaseComponent {
 
   static propTypes = {
     api: PropTypes.object.isRequired

--- a/app/components/PlayContainer.js
+++ b/app/components/PlayContainer.js
@@ -1,8 +1,9 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import lodash from 'lodash';
 import Play from './Play';
+import BaseComponent from '../BaseComponent';
 
-export default class PlayContainer extends Component {
+export default class PlayContainer extends BaseComponent {
 
   static propTypes = {
     user: PropTypes.object.isRequired

--- a/app/components/Reset.js
+++ b/app/components/Reset.js
@@ -1,7 +1,8 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import Icon from './Icon';
+import BaseComponent from '../BaseComponent';
 
-export default class Reset extends Component {
+export default class Reset extends BaseComponent {
 
   static propTypes = {
     type: PropTypes.string.isRequired,

--- a/app/components/ResetBar.js
+++ b/app/components/ResetBar.js
@@ -1,9 +1,10 @@
-import React, { Component } from 'react';
+import React from 'react';
 import style from './ResetBar.css';
 import Icon from './Icon.js';
 import Reset from '../components/Reset';
+import BaseComponent from '../BaseComponent';
 
-export default class ResetBar extends Component {
+export default class ResetBar extends BaseComponent {
 
   handleSuggestionsClick = () => {
     const suggestions = 'http://goo.gl/forms/AVaggClVWuIyP87k1';

--- a/app/components/Times.js
+++ b/app/components/Times.js
@@ -1,13 +1,14 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import classNames from 'classnames/bind';
 import Button from './Button';
 import Icon from '../components/Icon';
 import buttonStyle from '../components/Button.css';
 import style from '../components/Play.css';
+import BaseComponent from '../BaseComponent';
 
 const cx = classNames.bind(style);
 
-export default class Times extends Component {
+export default class Times extends BaseComponent {
 
   static propTypes = {
     liveTimes: PropTypes.array.isRequired,

--- a/app/components/ToggleDisplay.js
+++ b/app/components/ToggleDisplay.js
@@ -1,10 +1,11 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import classNames from 'classnames/bind';
 import style from './Toggle.css';
+import BaseComponent from '../BaseComponent';
 
 const cx = classNames.bind(style);
 
-export default class ToggleDisplay extends Component {
+export default class ToggleDisplay extends BaseComponent {
 
   static propTypes = {
     name: PropTypes.string.isRequired,

--- a/app/components/Variants.js
+++ b/app/components/Variants.js
@@ -1,13 +1,14 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import classNames from 'classnames/bind';
 import Button from './Button';
 import Icon from '../components/Icon';
 import style from '../components/Play.css';
 import buttonStyle from '../components/Button.css';
+import BaseComponent from '../BaseComponent';
 
 const cx = classNames.bind(style);
 
-export default class Variants extends Component {
+export default class Variants extends BaseComponent {
 
   static propTypes = {
     variants: PropTypes.array.isRequired,

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -1,12 +1,13 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import Header from '../components/Header';
 import NotificationBar from '../components/NotificationBar';
 import ResetBar from '../components/ResetBar';
 import PlayContainer from '../components/PlayContainer';
 import Options from '../components/Options/Options';
 import style from './App.css';
+import BaseComponent from '../BaseComponent';
 
-export default class App extends Component {
+export default class App extends BaseComponent {
 
   static propTypes = {
     user: PropTypes.object.isRequired,

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -1,8 +1,9 @@
 import xhr from 'xhr';
-import React, { Component } from 'react';
+import React from 'react';
 import App from './App';
+import BaseComponent from '../BaseComponent';
 
-export default class Root extends Component {
+export default class Root extends BaseComponent {
 
   constructor() {
     super();


### PR DESCRIPTION
Added a BaseComponent and made all components extend it, questions I can identify that are up for discussion are:

 - Where should BaseComponent be in the folder structure? Right now I put it in App as I kind of didn't feel it fits in either components or container as it's abstract in the sense that it doesn't have a render function. We could keep it in app or we could maybe make a new folder such as lib?

 - What do you think of the current shouldComponentUpdate? We could of course do a comprehensive equals as it also looks like we don't have any big objects in props or state currently so it probably wouldn't hurt performance too much, though it's dangerous starting to do all out equals, if we did that we could use a library such as lodash.

Looking forward to hear thoughts.

Also: This resolves #71 and fixes some of #70 as it stops the bug where opening the hide option will make hidden html elements re-appear (but doesn't solve all of #70 's problems).